### PR TITLE
Bug - Default values are getting overwritten

### DIFF
--- a/jquery.building-blocks.googleanalytics.js
+++ b/jquery.building-blocks.googleanalytics.js
@@ -112,7 +112,7 @@
     //    });
     //
     $.fn.gaTrackEvent = function (options) {
-        options = $.extend(defaultOptions, options);
+        options = $.extend({}, defaultOptions, options);
 
         return this.each(function () {
             var element = $(this);
@@ -139,7 +139,7 @@
     $.fn.gaTrackEventUnobtrusive = function (options) {
 
         //Merge options
-        options = $.extend(defaultOptions, options);
+        options = $.extend({}, defaultOptions, options);
 
         //Keep the chain going
         return this.each(function () {


### PR DESCRIPTION
Whith $.extend() it will overwrite the first object with the properties from the second.  In our project, we had different values for the labelAttribute (one was a href) so it was causing issues because it was 'remembering' href even when we were not using it.

This helped fix it for us, wanted to send this back.
Thanks for building the plugin!
