### PR TITLE
Add auto-detecting of ga/_gaq variable

### DIFF
--- a/jquery.building-blocks.googleanalytics.js
+++ b/jquery.building-blocks.googleanalytics.js
@@ -59,7 +59,14 @@
                     nonInteractive:false
                 };
                 args = $.extend(defaultArgs,args);
-                _gaq.push(['_trackEvent', args.category, args.action, args.label, args.value, args.nonInteractive]);
+
+                if (typeof ga !== 'undefined') {
+                    ga('send', 'event', args.category, args.action, args.label, args.value, {'nonInteraction': args.nonInteractive});
+                } else if (typeof _gaq !== 'undefined') {
+                    _gaq.push(['_trackEvent', args.category, args.action, args.label, args.value, args.nonInteractive]);
+                } else {
+                    throw new ReferenceError("ga and _gaq are both undefined.");
+                }
             }
         }
     });
@@ -128,7 +135,7 @@
             if (options.nonInteractive === true) {
             	element.attr(options.noninteractiveAttribute, "true");
             }
-            
+
             element.gaTrackEventUnobtrusive(options);
         });
     };


### PR DESCRIPTION
Google Analytics provides new version (asynchronous) of tracking code, that uses `ga` variable to handle. But when I using your plugin, I found that it's only used `_gaq`. 

So this fix want to help adding auto detecting feature to detect which version of GA tracking is used, and executing the specific event tracking code.

Thanks! :)
