### PR TITLE
quotations on 'click' value for event param in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Notice we've given it a class of "track-click".  We need to call the plugin in o
 
 		useLabel:true,
 
-		event: click
+		event: 'click'
 
 	});
 


### PR DESCRIPTION
I didn't notice this until I copied and pasted the example to test it, and then got an error. 