### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#What Google Analytics Plugin?
+# What Google Analytics Plugin?
 
 It's a jQuery plugin that tries to standardise and simplify the way event tracking is implemented within a project. It makes use of HTML5 data attributes and jQuery to try and minimise the effort and cross cutting concerns that tracking often puts into a project.
 
 It was created by Robert Stevenson-Leggett at <a href="http://www.building-blocks.com">Building Blocks</a> and is licenced under the MIT licence.
 
-#Version History
+# Version History
  - 0.8 - Bug fix with *BREAKING CHANGE!* $.ga.trackEvent has has its signature changed.
  - 0.7 - Added support for non interactive option
  - 0.6 - Bug fixes
@@ -14,11 +14,11 @@ It was created by Robert Stevenson-Leggett at <a href="http://www.building-block
  - 0.2 - Support for direct calling
  - 0.1 - Initial version
 
-#Usage
+# Usage
 
 There are 4 ways to use the plugin. Not all of these will fit every situation.
 
-##Method 1 - Simple Unobtrusive Tracking
+## Method 1 - Simple Unobtrusive Tracking
 
 Unobtrusive in combination with server side or just HTML. You output a span or any other element to the page and include a class of "track-me" for example:
 
@@ -30,7 +30,7 @@ Then in your Javascript initialisation code, you just call the plugin thusly:
 
 In one ASP.NET project, I have encapsulated the span inside a user control that can be hidden and shown at will and also has a setting to only track an event once for a user e.g. Registering. via the use of cookies (I may move this functionality into the plugin soon).
 
-##Method 2 - Unobtrusively Tracking An User Interaction
+## Method 2 - Unobtrusively Tracking An User Interaction
 
 Many of the events that we would like to track are things which do not trigger a post to the server. In this case we need to call the event on a user interaction. For example if we want to track removing of bookmarks from a list and this is an ajax request.
 
@@ -52,7 +52,7 @@ Notice we've given it a class of "track-click".  We need to call the plugin in o
 
 This will look for any element with the class of "track-click" and track clicks on it based on whatever data was attached via the data attributes. We can control the event here for example we could change "click" to hover or any other event. 
 
-##Method 3 - Tracking An User Interaction Without The Data Attributes.
+## Method 3 - Tracking An User Interaction Without The Data Attributes.
 
 Sometimes for some reason you might not want to use data attributes directly on the element in your user controls or html, so the plugin provides a way to add the attributes from javascript. This is good for adding events to an existing code base, you could hook onto existing classes 
 
@@ -81,7 +81,7 @@ This works like so:
 
 	$.ga.trackEvent({ category : 'Category', action : 'Action', label : 'Label', value: 0.1, nonInteractive: false });
 
-##Available options
+## Available options
 
 There are many options to make the plugin a bit more flexible. Including callback hook functions to evaluate whether to perform tracking These are the default options, you can override any of these by passing them to the plugin.
 
@@ -137,7 +137,7 @@ There are many options to make the plugin a bit more flexible. Including callbac
     };
 
 
-#Installation
+# Installation
 
 You can install this into your project using [Bower](http://bower.io):
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
